### PR TITLE
Add trigger for quantity loss and scheduled sampling during training

### DIFF
--- a/examples/aishell/s5/conf/asr/blstm_las.yaml
+++ b/examples/aishell/s5/conf/asr/blstm_las.yaml
@@ -58,7 +58,6 @@ dropout_emb: 0.4
 dropout_att: 0.0
 weight_decay: 1e-6
 ss_prob: 0.2
-ss_type: constant
 lsm_prob: 0.1
 ### MTL
 ctc_weight: 0.3

--- a/examples/ci_test/conf/asr/blstm_ctc.yaml
+++ b/examples/ci_test/conf/asr/blstm_ctc.yaml
@@ -42,13 +42,7 @@ param_init: 0.1
 clip_grad_norm: 5.0
 dropout_in: 0.1
 dropout_enc: 0.1
-dropout_dec: 0.1
-dropout_emb: 0.1
-dropout_att: 0.1
 weight_decay: 1e-6
-ss_prob: 0.1
-ss_type: constant
-lsm_prob: 0.1
 ### MTL
 ctc_weight: 1.0
 ctc_lsm_prob: 0.1

--- a/examples/ci_test/conf/asr/blstm_las.yaml
+++ b/examples/ci_test/conf/asr/blstm_las.yaml
@@ -58,7 +58,6 @@ dropout_emb: 0.1
 dropout_att: 0.1
 weight_decay: 1e-6
 ss_prob: 0.1
-ss_type: constant
 lsm_prob: 0.1
 ### MTL
 ctc_weight: 0.3

--- a/examples/ci_test/conf/asr/blstm_las_2mtl.yaml
+++ b/examples/ci_test/conf/asr/blstm_las_2mtl.yaml
@@ -60,7 +60,6 @@ dropout_emb: 0.1
 dropout_att: 0.1
 weight_decay: 1e-6
 ss_prob: 0.1
-ss_type: constant
 lsm_prob: 0.1
 ### MTL
 ctc_weight: 0.3

--- a/examples/ci_test/conf/asr/blstm_las_2mtl_per_batch.yaml
+++ b/examples/ci_test/conf/asr/blstm_las_2mtl_per_batch.yaml
@@ -60,7 +60,6 @@ dropout_emb: 0.1
 dropout_att: 0.1
 weight_decay: 1e-6
 ss_prob: 0.1
-ss_type: constant
 lsm_prob: 0.1
 ### MTL
 ctc_weight: 0.3

--- a/examples/ci_test/conf/asr/tds_las.yaml
+++ b/examples/ci_test/conf/asr/tds_las.yaml
@@ -47,7 +47,6 @@ dropout_emb: 0.1
 dropout_att: 0.1
 weight_decay: 1e-6
 ss_prob: 0.1
-ss_type: constant
 lsm_prob: 0.1
 ### MTL
 ctc_weight: 0.3

--- a/examples/ci_test/conf/asr/transformer_las.yaml
+++ b/examples/ci_test/conf/asr/transformer_las.yaml
@@ -50,6 +50,7 @@ dropout_dec: 0.1
 dropout_emb: 0.1
 dropout_att: 0.1
 weight_decay: 1e-6
+ss_prob: 0.1
 lsm_prob: 0.1
 ### MTL
 ctc_weight: 0.3

--- a/examples/csj/s5/conf/asr/blstm_las.yaml
+++ b/examples/csj/s5/conf/asr/blstm_las.yaml
@@ -35,7 +35,7 @@ batch_size: 30
 optimizer: adam
 n_epochs: 25
 convert_to_sgd_epoch: 100
-print_step: 400
+print_step: 800
 metric: edit_distance
 lr: 1e-3
 lr_decay_type: always
@@ -58,7 +58,6 @@ dropout_emb: 0.4
 dropout_att: 0.0
 weight_decay: 1e-6
 ss_prob: 0.2
-ss_type: constant
 lsm_prob: 0.1
 ### MTL
 ctc_weight: 0.3

--- a/examples/csj/s5/conf/asr/blstm_las_2mtl.yaml
+++ b/examples/csj/s5/conf/asr/blstm_las_2mtl.yaml
@@ -35,7 +35,7 @@ batch_size: 40
 optimizer: adam
 n_epochs: 25
 convert_to_sgd_epoch: 100
-print_step: 400
+print_step: 800
 metric: edit_distance
 lr: 1e-3
 lr_decay_type: always
@@ -58,7 +58,6 @@ dropout_emb: 0.4
 dropout_att: 0.0
 weight_decay: 1e-6
 ss_prob: 0.2
-ss_type: constant
 lsm_prob: 0.1
 ### MTL
 ctc_weight: 0.0

--- a/examples/csj/s5/conf/asr/lcblstm_las_chunk4040.yaml
+++ b/examples/csj/s5/conf/asr/lcblstm_las_chunk4040.yaml
@@ -58,7 +58,6 @@ dropout_emb: 0.4
 dropout_att: 0.0
 weight_decay: 1e-6
 ss_prob: 0.2
-ss_type: constant
 lsm_prob: 0.1
 ### MTL
 ctc_weight: 0.3

--- a/examples/csj/s5/conf/asr/lstm_las.yaml
+++ b/examples/csj/s5/conf/asr/lstm_las.yaml
@@ -32,7 +32,7 @@ batch_size: 30
 optimizer: adam
 n_epochs: 25
 convert_to_sgd_epoch: 100
-print_step: 400
+print_step: 800
 metric: edit_distance
 lr: 1e-3
 lr_decay_type: always
@@ -55,7 +55,6 @@ dropout_emb: 0.4
 dropout_att: 0.0
 weight_decay: 1e-6
 ss_prob: 0.2
-ss_type: constant
 lsm_prob: 0.1
 ### MTL
 ctc_weight: 0.3

--- a/examples/librispeech/s5/conf/asr/blstm_las.yaml
+++ b/examples/librispeech/s5/conf/asr/blstm_las.yaml
@@ -58,7 +58,6 @@ dropout_emb: 0.4
 dropout_att: 0.0
 weight_decay: 1e-6
 ss_prob: 0.2
-ss_type: constant
 lsm_prob: 0.1
 ### MTL
 ctc_weight: 0.3

--- a/examples/swbd/s5c/conf/asr/blstm_las.yaml
+++ b/examples/swbd/s5c/conf/asr/blstm_las.yaml
@@ -58,7 +58,6 @@ dropout_emb: 0.4
 dropout_att: 0.0
 weight_decay: 1e-6
 ss_prob: 0.2
-ss_type: constant
 lsm_prob: 0.1
 ### MTL
 ctc_weight: 0.3

--- a/examples/swbd/s5c/conf/asr/blstm_las_2mtl.yaml
+++ b/examples/swbd/s5c/conf/asr/blstm_las_2mtl.yaml
@@ -58,7 +58,6 @@ dropout_emb: 0.4
 dropout_att: 0.0
 weight_decay: 1e-6
 ss_prob: 0.2
-ss_type: constant
 lsm_prob: 0.1
 ### MTL
 ctc_weight: 0.0

--- a/examples/swbd/s5c/conf/asr/blstm_las_3mtl.yaml
+++ b/examples/swbd/s5c/conf/asr/blstm_las_3mtl.yaml
@@ -60,7 +60,6 @@ dropout_emb: 0.4
 dropout_att: 0.0
 weight_decay: 1e-6
 ss_prob: 0.2
-ss_type: constant
 lsm_prob: 0.1
 ### MTL
 ctc_weight: 0.0

--- a/examples/swbd/s5c/conf/asr/blstm_las_fisher_swbd.yaml
+++ b/examples/swbd/s5c/conf/asr/blstm_las_fisher_swbd.yaml
@@ -56,7 +56,6 @@ dropout_emb: 0.4
 dropout_att: 0.0
 weight_decay: 1e-6
 ss_prob: 0.2
-ss_type: constant
 lsm_prob: 0.1
 ### MTL
 ctc_weight: 0.0

--- a/examples/tedlium/s5_r2/conf/asr/blstm_las.yaml
+++ b/examples/tedlium/s5_r2/conf/asr/blstm_las.yaml
@@ -58,7 +58,6 @@ dropout_emb: 0.4
 dropout_att: 0.0
 weight_decay: 1e-6
 ss_prob: 0.2
-ss_type: constant
 lsm_prob: 0.1
 ### MTL
 ctc_weight: 0.3

--- a/examples/tedlium/s5_r2/conf/asr/blstm_las_ctc_sync.yaml
+++ b/examples/tedlium/s5_r2/conf/asr/blstm_las_ctc_sync.yaml
@@ -60,7 +60,6 @@ dropout_emb: 0.4
 dropout_att: 0.0
 weight_decay: 1e-6
 ss_prob: 0.2
-ss_type: constant
 lsm_prob: 0.1
 ### MTL
 ctc_weight: 0.3

--- a/examples/tedlium/s5_r2/conf/asr/lcblstm_las_chunk4020.yaml
+++ b/examples/tedlium/s5_r2/conf/asr/lcblstm_las_chunk4020.yaml
@@ -58,7 +58,6 @@ dropout_emb: 0.4
 dropout_att: 0.0
 weight_decay: 1e-6
 ss_prob: 0.2
-ss_type: constant
 lsm_prob: 0.1
 ### MTL
 ctc_weight: 0.3

--- a/examples/tedlium/s5_r2/conf/asr/lcblstm_las_chunk4040.yaml
+++ b/examples/tedlium/s5_r2/conf/asr/lcblstm_las_chunk4040.yaml
@@ -58,7 +58,6 @@ dropout_emb: 0.4
 dropout_att: 0.0
 weight_decay: 1e-6
 ss_prob: 0.2
-ss_type: constant
 lsm_prob: 0.1
 ### MTL
 ctc_weight: 0.3

--- a/examples/tedlium/s5_r2/conf/asr/lstm_las.yaml
+++ b/examples/tedlium/s5_r2/conf/asr/lstm_las.yaml
@@ -55,7 +55,6 @@ dropout_emb: 0.4
 dropout_att: 0.0
 weight_decay: 1e-6
 ss_prob: 0.2
-ss_type: constant
 lsm_prob: 0.1
 ### MTL
 ctc_weight: 0.3

--- a/examples/tedlium/s5_r3/conf/asr/blstm_las.yaml
+++ b/examples/tedlium/s5_r3/conf/asr/blstm_las.yaml
@@ -1,7 +1,7 @@
 ### topology
 n_stacks: 1
 n_skips: 1
-max_n_frames: 2000
+max_n_frames: 1600
 conv_in_channel: 1
 conv_channels: "32_32"
 conv_kernel_sizes: "(3,3)_(3,3)"
@@ -24,7 +24,7 @@ dec_type: lstm
 dec_n_units: 1024
 dec_n_projs: 0
 dec_n_layers: 1
-dec_bottleneck_dim: 1024
+dec_bottleneck_dim: 512
 emb_dim: 512
 tie_embedding: false
 ctc_fc_list: "512"
@@ -33,7 +33,7 @@ batch_size: 50
 optimizer: adam
 n_epochs: 25
 convert_to_sgd_epoch: 20
-print_step: 200
+print_step: 400
 metric: edit_distance
 lr: 1e-3
 lr_decay_type: always
@@ -56,7 +56,6 @@ dropout_emb: 0.4
 dropout_att: 0.0
 weight_decay: 1e-6
 ss_prob: 0.2
-ss_type: constant
 lsm_prob: 0.1
 ### MTL
 ctc_weight: 0.0

--- a/examples/tedlium/s5_r3/conf/asr/blstm_las.yaml
+++ b/examples/tedlium/s5_r3/conf/asr/blstm_las.yaml
@@ -15,6 +15,8 @@ enc_n_units: 512
 enc_n_projs: 0
 enc_n_layers: 5
 subsample_type: drop
+lc_chunk_size_left: -1  ### offline
+lc_chunk_size_right: 40
 attn_type: location
 attn_conv_n_channels: 10
 attn_conv_width: 201
@@ -24,7 +26,7 @@ dec_type: lstm
 dec_n_units: 1024
 dec_n_projs: 0
 dec_n_layers: 1
-dec_bottleneck_dim: 512
+dec_bottleneck_dim: 1024  ### this is effective
 emb_dim: 512
 tie_embedding: false
 ctc_fc_list: "512"
@@ -60,6 +62,5 @@ lsm_prob: 0.1
 ### MTL
 ctc_weight: 0.0
 ctc_lsm_prob: 0.1
-bwd_weight: 0.0
 mtl_per_batch: false
 task_specific_layer: false

--- a/examples/timit/s5/conf/blstm_las.yaml
+++ b/examples/timit/s5/conf/blstm_las.yaml
@@ -2,7 +2,7 @@
 n_stacks: 1
 n_skips: 1
 max_n_frames: 2000
-gaussian_noise: false
+input_noise_std: 0
 conv_in_channel: 3
 conv_channels: "32_32"
 conv_kernel_sizes: "(3,3)_(3,3)"

--- a/examples/wsj/s5/conf/asr/blstm_las.yaml
+++ b/examples/wsj/s5/conf/asr/blstm_las.yaml
@@ -58,7 +58,6 @@ dropout_emb: 0.4
 dropout_att: 0.0
 weight_decay: 1e-6
 ss_prob: 0.2
-ss_type: constant
 lsm_prob: 0.1
 ### MTL
 ctc_weight: 0.3

--- a/neural_sp/bin/args_asr.py
+++ b/neural_sp/bin/args_asr.py
@@ -276,11 +276,6 @@ def build_parser():
                         help='dropout probability for the attention weights')
     parser.add_argument('--weight_decay', type=float, default=0,
                         help='weight decay parameter')
-    parser.add_argument('--ss_prob', type=float, default=0.0,
-                        help='probability of scheduled sampling')
-    parser.add_argument('--ss_type', type=str, default='constant',
-                        choices=['constant', 'ramp'],
-                        help='type of scheduled sampling')
     parser.add_argument('--lsm_prob', type=float, default=0.0,
                         help='probability of label smoothing')
     parser.add_argument('--ctc_lsm_prob', type=float, default=0.0,

--- a/neural_sp/bin/asr/train.py
+++ b/neural_sp/bin/asr/train.py
@@ -290,6 +290,11 @@ def main():
     else:
         tasks = ['all']
 
+    if getattr(args, 'ss_start_epoch', 0) <= resume_epoch:
+        model.module.trigger_scheduled_sampling()
+    if getattr(args, 'mocha_quantity_loss_start_epoch', 0) <= resume_epoch:
+        model.module.trigger_quantity_loss()
+
     start_time_train = time.time()
     start_time_epoch = time.time()
     start_time_step = time.time()
@@ -431,8 +436,10 @@ def main():
 
         if scheduler.n_epochs >= args.n_epochs:
             break
-        # if args.ss_prob > 0:
-        #     model.module.scheduled_sampling_trigger()
+        if getattr(args, 'ss_start_epoch', 0) == (ep + 1):
+            model.module.trigger_scheduled_sampling()
+        if getattr(args, 'mocha_quantity_loss_start_epoch', 0) == (ep + 1):
+            model.module.trigger_quantity_loss()
 
         start_time_step = time.time()
         start_time_epoch = time.time()

--- a/neural_sp/bin/model_name.py
+++ b/neural_sp/bin/model_name.py
@@ -1,6 +1,3 @@
-#! /usr/bin/env python3
-# -*- coding: utf-8 -*-
-
 # Copyright 2019 Kyoto University (Hirofumi Inaguma)
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -94,8 +91,6 @@ def set_asr_model_name(args):
     #     dir_name += '_' + args.transformer_param_init
 
     # regularization
-    if args.ctc_weight < 1 and args.ss_prob > 0:
-        dir_name += '_ss' + str(args.ss_prob)
     if args.lsm_prob > 0:
         dir_name += '_ls' + str(args.lsm_prob)
     if args.warmup_n_steps > 0:
@@ -146,9 +141,9 @@ def set_asr_model_name(args):
         if args.adaptive_size_ratio > 0:
             dir_name += '_psize' + str(args.adaptive_size_ratio)
     if args.input_noise_std > 0:
-        dir_name += '_inputnoisestd'
+        dir_name += '_Inoise'
     if args.weight_noise_std > 0:
-        dir_name += '_weightnoisestd'
+        dir_name += '_Wnoise'
 
     # contextualization
     if args.discourse_aware:

--- a/neural_sp/models/seq2seq/decoders/build.py
+++ b/neural_sp/models/seq2seq/decoders/build.py
@@ -1,6 +1,3 @@
-#! /usr/bin/env python3
-# -*- coding: utf-8 -*-
-
 # Copyright 2019 Kyoto University (Hirofumi Inaguma)
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -113,7 +110,6 @@ def build_decoder(args, special_symbols, enc_n_units, vocab,
             dropout_att=args.dropout_att,
             lsm_prob=args.lsm_prob,
             ss_prob=args.ss_prob,
-            ss_type=args.ss_type,
             ctc_weight=ctc_weight,
             ctc_lsm_prob=args.ctc_lsm_prob,
             ctc_fc_list=ctc_fc_list,

--- a/neural_sp/models/seq2seq/decoders/decoder_base.py
+++ b/neural_sp/models/seq2seq/decoders/decoder_base.py
@@ -31,6 +31,12 @@ class DecoderBase(ModelBase):
     def reset_session(self):
         self.new_session = True
 
+    def trigger_scheduled_sampling(self):
+        self._ss_prob = getattr(self, 'ss_prob', 0)
+
+    def trigger_quantity_loss(self):
+        self._quantity_loss_weight = getattr(self, 'quantity_loss_weight', 0)
+
     def greedy(self, eouts, elens, max_len_ratio):
         raise NotImplementedError
 

--- a/neural_sp/models/seq2seq/decoders/rnn_transducer.py
+++ b/neural_sp/models/seq2seq/decoders/rnn_transducer.py
@@ -1,6 +1,3 @@
-#! /usr/bin/env python3
-# -*- coding: utf-8 -*-
-
 # Copyright 2019 Kyoto University (Hirofumi Inaguma)
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -177,9 +174,6 @@ class RNNTransducer(DecoderBase):
                 logger.info('Initialize %s with %s / %.3f' % (n, 'uniform', param_init))
             else:
                 raise ValueError(n)
-
-    def start_scheduled_sampling(self):
-        self._ss_prob = 0.
 
     def forward(self, eouts, elens, ys, task='all',
                 teacher_logits=None, recog_params={}, idx2token=None, trigger_points=None):

--- a/neural_sp/models/seq2seq/speech2text.py
+++ b/neural_sp/models/seq2seq/speech2text.py
@@ -191,21 +191,24 @@ class Speech2Text(ModelBase):
                 else:
                     p.requires_grad = False
 
-    def scheduled_sampling_trigger(self):
+    def trigger_scheduled_sampling(self):
         # main task
         for dir in ['fwd', 'bwd']:
             if hasattr(self, 'dec_' + dir):
-                getattr(self, 'dec_' + dir).start_scheduled_sampling()
+                logging.info('Activate scheduled sampling (main)')
+                getattr(self, 'dec_' + dir).trigger_scheduled_sampling()
 
         # sub task
         for sub in ['sub1', 'sub2']:
             if hasattr(self, 'dec_fwd_' + sub):
-                getattr(self, 'dec_fwd_' + sub).start_scheduled_sampling()
+                logging.info('Activate scheduled sampling (%s)' % sub)
+                getattr(self, 'dec_fwd_' + sub).trigger_scheduled_sampling()
 
-    def mocha_quantity_loss_trigger(self):
+    def trigger_quantity_loss(self):
         # main task only now
         if hasattr(self, 'dec_fwd'):
-            getattr(self, 'dec_fwd').start_mocha_quantity_loss()
+            logging.info('Activate quantity loss')
+            getattr(self, 'dec_fwd').trigger_quantity_loss()
 
     def reset_session(self):
         # main task

--- a/test/decoders/test_las_decoder.py
+++ b/test/decoders/test_las_decoder.py
@@ -41,7 +41,6 @@ def make_args(**kwargs):
         dropout_att=0.1,
         lsm_prob=0.0,
         ss_prob=0.0,
-        ss_type='constant',
         ctc_weight=0.0,
         ctc_lsm_prob=0.1,
         ctc_fc_list='16_16',


### PR DESCRIPTION
This PR adds a trigger to start quantity loss and scheduled sampling during training. For example, you can turn on quantity loss at the end of the 5th epoch.