### PR TITLE
Refactor streaming decoding in MoChA

### DIFF
--- a/neural_sp/models/modules/attention.py
+++ b/neural_sp/models/modules/attention.py
@@ -92,7 +92,7 @@ class AttentionMechanism(nn.Module):
         self.mask = None
 
     def forward(self, key, value, query, mask=None, aw_prev=None,
-                cache=False, mode='', trigger_points=None):
+                cache=False, mode='', trigger_points=None, streaming=False):
         """Forward pass.
 
         Args:
@@ -105,6 +105,7 @@ class AttentionMechanism(nn.Module):
             cache (bool): cache key and mask
             mode: dummy interface for MoChA/MMA
             trigger_points (IntTensor): `[B]`
+            streaming: dummy interface for streaming attention
         Returns:
             cv (FloatTensor): `[B, 1, vdim]`
             aw (FloatTensor): `[B, 1 (H), 1 (qlen), klen]`

--- a/neural_sp/models/modules/cif.py
+++ b/neural_sp/models/modules/cif.py
@@ -53,7 +53,7 @@ class CIF(nn.Module):
         for n, p in self.named_parameters():
             init_with_xavier_uniform(n, p)
 
-    def forward(self, eouts, elens, ylens=None, mode='parallel'):
+    def forward(self, eouts, elens, ylens=None, mode='parallel', streaming=False):
         """Forward pass.
 
         Args:
@@ -61,6 +61,7 @@ class CIF(nn.Module):
             elens (IntTensor): `[B]`
             ylens (IntTensor): `[B]`
             mode (str): parallel/incremental
+            streaming: dummy interface for streaming attention
         Returns:
             cv (FloatTensor): `[B, L, enc_dim]`
             alpha (FloatTensor): `[B, T]`

--- a/neural_sp/models/modules/gmm_attention.py
+++ b/neural_sp/models/modules/gmm_attention.py
@@ -60,7 +60,8 @@ class GMMAttention(nn.Module):
 
     def reset_parameters_xavier_uniform(self):
         """Initialize parameters with Xavier uniform distribution."""
-        logger.info('===== Initialize %s with Xavier uniform distribution =====' % self.__class__.__name__)
+        logger.info('===== Initialize %s with Xavier uniform distribution =====' %
+                    self.__class__.__name__)
         for n, p in self.named_parameters():
             init_with_xavier_uniform(n, p)
 
@@ -69,7 +70,7 @@ class GMMAttention(nn.Module):
         self.myu = None
 
     def forward(self, key, value, query, mask=None, aw_prev=None,
-                cache=False, mode='', trigger_points=None):
+                cache=False, mode='', trigger_points=None, streaming=False):
         """Forward pass.
 
         Args:
@@ -81,6 +82,7 @@ class GMMAttention(nn.Module):
             cache (bool): cache key and mask
             mode: dummy interface for MoChA/MMA
             trigger_points: dummy interface for MoChA/MMA
+            streaming: dummy interface for streaming attention
         Returns:
             cv (FloatTensor): `[B, 1, vdim]`
             aw (FloatTensor): `[B, 1 (H), 1 (qlen), klen]`

--- a/neural_sp/models/modules/mocha.py
+++ b/neural_sp/models/modules/mocha.py
@@ -120,6 +120,7 @@ class MonotonicEnergy(nn.Module):
             if self.conv1d is not None:
                 key = torch.relu(self.conv1d(key))
             self.key = self.w_key(key)  # `[B, klen, adim]`
+            self.key = self.key.view(-1, klen, self.n_heads, self.d_k)  # `[B, klen, H_ma, d_k]`
             if mask is not None:
                 self.mask = mask.unsqueeze(3).repeat([1, 1, 1, self.n_heads])  # `[B, qlen, klen, H_ca]`
                 mask_size = (bs, qlen, klen, self.n_heads)

--- a/neural_sp/models/modules/multihead_attention.py
+++ b/neural_sp/models/modules/multihead_attention.py
@@ -68,7 +68,8 @@ class MultiheadAttentionMechanism(nn.Module):
 
     def reset_parameters(self, bias):
         """Initialize parameters with Xavier uniform distribution."""
-        logger.info('===== Initialize %s with Xavier uniform distribution =====' % self.__class__.__name__)
+        logger.info('===== Initialize %s with Xavier uniform distribution =====' %
+                    self.__class__.__name__)
         # NOTE: see https://github.com/pytorch/fairseq/blob/master/fairseq/modules/multihead_attention.py
         nn.init.xavier_uniform_(self.w_key.weight, gain=1 / math.sqrt(2))
         nn.init.xavier_uniform_(self.w_value.weight, gain=1 / math.sqrt(2))
@@ -87,8 +88,8 @@ class MultiheadAttentionMechanism(nn.Module):
         self.value = None
         self.mask = None
 
-    def forward(self, key, value, query, mask, aw_prev=None,
-                cache=False, mode='', trigger_points=None, eps_wait=-1):
+    def forward(self, key, value, query, mask, aw_prev=None, aw_lower=None,
+                cache=False, mode='', trigger_points=None, eps_wait=-1, streaming=False):
         """Forward pass.
 
         Args:
@@ -101,6 +102,7 @@ class MultiheadAttentionMechanism(nn.Module):
             mode: dummy interface for MoChA/MMA
             trigger_points: dummy interface for MoChA/MMA
             eps_wait: dummy interface for MMA
+            streaming: dummy interface for streaming attention
         Returns:
             cv (FloatTensor): `[B, qlen, vdim]`
             aw (FloatTensor): `[B, H, qlen, klen]`
@@ -115,11 +117,12 @@ class MultiheadAttentionMechanism(nn.Module):
         if self.key is None or not cache:
             self.key = self.w_key(key).view(bs, -1, self.n_heads, self.d_k)  # `[B, klen, H, d_k]`
             self.value = self.w_value(value).view(bs, -1, self.n_heads, self.d_k)  # `[B, klen, H, d_k]`
-            self.mask = mask
-            if self.mask is not None:
-                self.mask = self.mask.unsqueeze(3).repeat([1, 1, 1, self.n_heads])
+            if mask is not None:
+                self.mask = mask.unsqueeze(3).repeat([1, 1, 1, self.n_heads])
                 mask_size = (bs, qlen, klen, self.n_heads)
                 assert self.mask.size() == mask_size, (self.mask.size(), mask_size)
+            else:
+                self.mask = None
 
         key = self.key
         query = self.w_query(query).view(bs, -1, self.n_heads, self.d_k)  # `[B, qlen, H, d_k]`

--- a/test/modules/test_mocha.py
+++ b/test/modules/test_mocha.py
@@ -173,7 +173,7 @@ def test_forward_hard(args):
             cv, alpha, beta, p_choose = out
             assert cv.size() == (batch_size, 1, value.size(2))
             assert alpha.size() == (batch_size, args['n_heads_mono'], 1, klen)
-            assert p_choose is None
+            assert p_choose.size() == (batch_size, args['n_heads_mono'], 1, klen)
             if args['chunk_size'] > 1:
                 assert beta is not None
                 assert beta.size() == (batch_size, args['n_heads_mono'] * args['n_heads_chunk'], 1, klen)

--- a/test/modules/test_mocha.py
+++ b/test/modules/test_mocha.py
@@ -92,7 +92,7 @@ def test_forward_soft_parallel(args):
     alpha = None
     for i in range(qlen):
         out = mocha(key, value, query[:, i:i + 1], mask=src_mask, aw_prev=alpha,
-                    mode='recursive', cache=True)
+                    mode='recursive', cache=True, linear_decoding=True)
         assert len(out) == 4
         cv, alpha, beta, p_choose = out
         assert cv.size() == (batch_size, 1, value.size(2))
@@ -107,7 +107,7 @@ def test_forward_soft_parallel(args):
     mocha.reset()
     for i in range(qlen):
         out = mocha(key, value, query[:, i:i + 1], mask=src_mask, aw_prev=alpha,
-                    mode='parallel', cache=True)
+                    mode='parallel', cache=True, linear_decoding=True)
         assert len(out) == 4
         cv, alpha, beta, p_choose = out
         assert cv.size() == (batch_size, 1, value.size(2))
@@ -165,7 +165,7 @@ def test_forward_hard(args):
     for i in range(qlen):
         out = mocha(key, value, query[:, i:i + 1], mask=None, aw_prev=alpha,
                     mode='hard', cache=False, trigger_points=trigger_points,
-                    eps_wait=-1, efficient_decoding=False)
+                    eps_wait=-1, linear_decoding=True)
         assert len(out) == 4
         cv, alpha, beta, p_choose = out
         assert cv.size() == (batch_size, 1, value.size(2))


### PR DESCRIPTION
- Cache tailed encoder outputs at the previous block inside MoChA module, instead of beam search module.
- Add linear-time decoding option