### PR TITLE
Minor fix in naming of chunk size

### DIFF
--- a/neural_sp/models/seq2seq/encoders/build.py
+++ b/neural_sp/models/seq2seq/encoders/build.py
@@ -150,7 +150,7 @@ def build_encoder(args):
             bidir_sum_fwd_bwd=args.bidirectional_sum_fwd_bwd,
             task_specific_layer=args.task_specific_layer,
             param_init=args.param_init,
-            chunk_size_left=args.lc_chunk_size_left,
+            chunk_size_current=args.lc_chunk_size_left,  # for compatibility
             chunk_size_right=args.lc_chunk_size_right,
             rsp_prob=args.rsp_prob_enc)
 

--- a/neural_sp/models/seq2seq/frontends/streaming.py
+++ b/neural_sp/models/seq2seq/frontends/streaming.py
@@ -127,7 +127,8 @@ class Streaming(object):
             x_block = np.concatenate([zero_pad, x_block], axis=0)
 
         # zero padding for the last blocks
-        if j > 0 and x_block.shape[0] != (N_l + N_c + N_r + self.conv_context * 2):
+        # if j > 0 and x_block.shape[0] != (N_l + N_c + N_r + self.conv_context * 2):
+        if x_block.shape[0] != (N_l + N_c + N_r + self.conv_context * 2):
             zero_pad = np.zeros(((N_l + N_c + N_r + self.conv_context * 2) - x_block.shape[0],
                                  self.feat_dim)).astype(np.float32)
             x_block = np.concatenate([x_block, zero_pad], axis=0)

--- a/neural_sp/models/seq2seq/frontends/streaming.py
+++ b/neural_sp/models/seq2seq/frontends/streaming.py
@@ -24,6 +24,7 @@ class Streaming(object):
 
         self.x_whole = x_whole
         # TODO: implement wav input
+        self.feat_dim = x_whole.shape[1]
         self.encoder = encoder
         if self.encoder.conv is not None:
             self.encoder.turn_off_ceil_mode(self.encoder)
@@ -31,11 +32,11 @@ class Streaming(object):
 
         # latency
         self._factor = encoder.subsampling_factor
-        self.N_l = encoder.chunk_size_left
-        self.N_c = getattr(encoder, 'chunk_size_current', 0)  # for Transformer
+        self.N_l = getattr(encoder, 'chunk_size_left', 0)  # for Transformer/Conformer
+        self.N_c = encoder.chunk_size_current
         self.N_r = encoder.chunk_size_right
-        if self.N_l <= 0 and self.N_r <= 0:
-            self.N_l = block_size  # for unidirectional encoder
+        if self.N_c <= 0 and self.N_r <= 0:
+            self.N_c = block_size  # for unidirectional encoder
             assert block_size % self._factor == 0
 
         # threshold for CTC-VAD
@@ -93,32 +94,41 @@ class Streaming(object):
         return torch.cat(self._eout_blocks, dim=1)
 
     def next_block(self):
-        self._offset += self.N_l
+        self._offset += self.N_c
 
     def extract_feature(self):
         j = self._offset
         N_l = self.N_l
+        N_c = self.N_c
         N_r = self.N_r
 
         # Encode input features block by block
-        if getattr(self.encoder, 'conv', None) is not None:
-            cnn_context = self.encoder.conv.context_size
-            x_block = self.x_whole[max(0, j - cnn_context):j + (N_l + N_r) + cnn_context]
-        else:
+        if getattr(self.encoder, 'conv', None) is None:
             cnn_context = 0
-            x_block = self.x_whole[j:j + (N_l + N_r)]
+        else:
+            cnn_context = self.encoder.conv.context_size
+        j_left = max(0, j - (cnn_context + N_l))
+        x_block = self.x_whole[j_left:j + (N_c + N_r + cnn_context)]
 
-        # zero paddign for the last block
-        if j > 0 and x_block.shape[0] != (N_l + N_r + cnn_context * 2):
-            zero_pad = np.zeros(((N_l + N_r + cnn_context * 2) - x_block.shape[0], x_block.shape[1])).astype(np.float32)
+        is_last_block = (j + N_c) >= len(self.x_whole)
+        # is_last_block = (j + 1 + N_c) >= len(self.x_whole)
+
+        # zero padding for the first blocks
+        if j_left == 0:
+            zero_pad = np.zeros((cnn_context + N_l - j, self.feat_dim)).astype(np.float32)
+            x_block = np.concatenate([zero_pad, x_block], axis=0)
+
+        # zero padding for the last blocks
+        if j > 0 and x_block.shape[0] != (N_l + N_c + N_r + cnn_context * 2):
+            zero_pad = np.zeros(((N_l + N_c + N_r + cnn_context * 2) - x_block.shape[0],
+                                 self.feat_dim)).astype(np.float32)
             x_block = np.concatenate([x_block, zero_pad], axis=0)
 
-        is_last_block = (j + N_l - 1) >= len(self.x_whole) - 1
         self._bd_offset = -1  # reset
-        self._n_accum_frames += min(self.N_l, x_block.shape[1])
+        self._n_accum_frames += min(self.N_c, self.feat_dim)
 
-        start = j - self.conv_n_lookahead
-        end = j + (N_l + N_r) + self.conv_n_lookahead
+        start = j - (self.conv_n_lookahead + N_l)
+        end = j + (N_c + N_r + self.conv_n_lookahead)
         lookback = start >= 0
         lookahead = end <= self.x_whole.shape[0] - 1
 
@@ -189,12 +199,12 @@ class Streaming(object):
         return is_reset
 
     def backoff(self, x_block, decoder, stdout=False):
-        if 0 <= self._bd_offset * self._factor < self.N_l - 1:
+        if 0 <= self._bd_offset * self._factor < self.N_c - 1:
             # boundary located in the middle of the current block
             decoder.n_frames = 0
             offset_prev = self._offset
-            self._offset = self._offset - x_block[(self._bd_offset + 1) * self._factor:self.N_l].shape[0]
+            self._offset = self._offset - x_block[(self._bd_offset + 1) * self._factor:self.N_c].shape[0]
             if stdout:
                 print('Back %d frames (%d -> %d)' %
-                      (x_block[(self._bd_offset + 1) * self._factor:self.N_l].shape[0],
+                      (x_block[(self._bd_offset + 1) * self._factor:self.N_c].shape[0],
                        offset_prev, self._offset))

--- a/test/encoders/test_rnn_encoder.py
+++ b/test/encoders/test_rnn_encoder.py
@@ -40,7 +40,7 @@ def make_args(**kwargs):
         bidir_sum_fwd_bwd=False,
         task_specific_layer=False,
         param_init=0.1,
-        chunk_size_left="0",
+        chunk_size_current="0",
         chunk_size_right="0",
         rsp_prob=0,
     )
@@ -113,49 +113,49 @@ def make_args(**kwargs):
         ({'enc_type': 'blstm', 'subsample': "1_2_2_1", 'subsample_type': 'add',
           'n_projs': 8}),
         # LC-BLSTM
-        ({'enc_type': 'blstm', 'chunk_size_left': "0", 'chunk_size_right': "40"}),  # BLSTM for PT
-        ({'enc_type': 'blstm', 'chunk_size_left': "40", 'chunk_size_right': "40"}),
+        ({'enc_type': 'blstm', 'chunk_size_current': "0", 'chunk_size_right': "40"}),  # BLSTM for PT
+        ({'enc_type': 'blstm', 'chunk_size_current': "40", 'chunk_size_right': "40"}),
         ({'enc_type': 'blstm', 'bidir_sum_fwd_bwd': True,
-          'chunk_size_left': "0", 'chunk_size_right': "40"}),  # BLSTM for PT
+          'chunk_size_current': "0", 'chunk_size_right': "40"}),  # BLSTM for PT
         ({'enc_type': 'blstm', 'bidir_sum_fwd_bwd': True,
-          'chunk_size_left': "40", 'chunk_size_right': "40"}),
+          'chunk_size_current': "40", 'chunk_size_right': "40"}),
         ({'enc_type': 'conv_blstm', 'bidir_sum_fwd_bwd': True,
-          'chunk_size_left': "40", 'chunk_size_right': "40"}),
+          'chunk_size_current': "40", 'chunk_size_right': "40"}),
         ({'enc_type': 'conv_blstm', 'bidir_sum_fwd_bwd': True,
-          'chunk_size_left': "40", 'chunk_size_right': "40", 'rsp_prob': 0.5}),
+          'chunk_size_current': "40", 'chunk_size_right': "40", 'rsp_prob': 0.5}),
         # LC-BLSTM + subsampling
         ({'enc_type': 'blstm', 'subsample': "1_2_1_1",
           'chunk_size_right': "40"}),  # BLSTM for PT
         ({'enc_type': 'blstm', 'subsample': "1_2_1_1",
-          'chunk_size_left': "40", 'chunk_size_right': "40"}),
+          'chunk_size_current': "40", 'chunk_size_right': "40"}),
         ({'enc_type': 'blstm', 'subsample': "1_2_1_1", 'bidir_sum_fwd_bwd': True,
           'chunk_size_right': "40"}),  # BLSTM for PT
         ({'enc_type': 'blstm', 'subsample': "1_2_1_1", 'bidir_sum_fwd_bwd': True,
-          'chunk_size_left': "40", 'chunk_size_right': "40"}),
+          'chunk_size_current': "40", 'chunk_size_right': "40"}),
         ({'enc_type': 'blstm', 'subsample': "1_2_1_1", 'bidir_sum_fwd_bwd': True,
-          'chunk_size_left': "40", 'chunk_size_right': "40", 'rsp_prob': 0.5}),
+          'chunk_size_current': "40", 'chunk_size_right': "40", 'rsp_prob': 0.5}),
         # Multi-task
         ({'enc_type': 'blstm', 'n_layers_sub1': 2}),
         ({'enc_type': 'blstm', 'n_layers_sub1': 2, 'task_specific_layer': True}),
         ({'enc_type': 'blstm', 'n_layers_sub1': 2, 'task_specific_layer': True,
-          'chunk_size_left': "0", 'chunk_size_right': "40"}),  # BLSTM for PT
+          'chunk_size_current': "0", 'chunk_size_right': "40"}),  # BLSTM for PT
         ({'enc_type': 'blstm', 'n_layers_sub1': 2, 'task_specific_layer': True,
-          'chunk_size_left': "40", 'chunk_size_right': "40"}),  # LC-BLSTM
+          'chunk_size_current': "40", 'chunk_size_right': "40"}),  # LC-BLSTM
         ({'enc_type': 'blstm', 'n_layers_sub1': 2, 'task_specific_layer': True,
-          'chunk_size_left': "0", 'chunk_size_right': "40",
+          'chunk_size_current': "0", 'chunk_size_right': "40",
           'rsp_prob': 0.5}),  # BLSTM for PT
         ({'enc_type': 'blstm', 'n_layers_sub1': 2, 'task_specific_layer': True,
-          'chunk_size_left': "40", 'chunk_size_right': "40",
+          'chunk_size_current': "40", 'chunk_size_right': "40",
           'rsp_prob': 0.5}),  # LC-BLSTM
         ({'enc_type': 'blstm', 'n_layers_sub1': 2, 'n_layers_sub2': 1}),
         ({'enc_type': 'blstm', 'n_layers_sub1': 2, 'n_layers_sub2': 1,
           'task_specific_layer': True}),
         # Multi-task + subsampling
         ({'enc_type': 'blstm', 'subsample': "2_1_1_1", 'n_layers_sub1': 2,
-          'chunk_size_left': "0", 'chunk_size_right': "40",
+          'chunk_size_current': "0", 'chunk_size_right': "40",
           'task_specific_layer': True}),  # BLSTM for PT
         ({'enc_type': 'blstm', 'subsample': "2_1_1_1", 'n_layers_sub1': 2,
-          'chunk_size_left': "40", 'chunk_size_right': "40",
+          'chunk_size_current': "40", 'chunk_size_right': "40",
           'task_specific_layer': True}),  # LC-BLSTM
     ]
 )
@@ -163,7 +163,7 @@ def test_forward(args):
     args = make_args(**args)
 
     batch_size = 4
-    xmaxs = [40, 45] if int(args['chunk_size_left'].split('_')[0]) == -1 else [400, 455]
+    xmaxs = [40, 45] if int(args['chunk_size_current'].split('_')[0]) == -1 else [400, 455]
     device = "cpu"
 
     module = importlib.import_module('neural_sp.models.seq2seq.encoders.rnn')

--- a/test/encoders/test_rnn_encoder_streaming_chunkwise.py
+++ b/test/encoders/test_rnn_encoder_streaming_chunkwise.py
@@ -42,7 +42,6 @@ def make_args(**kwargs):
         bidir_sum_fwd_bwd=False,
         task_specific_layer=False,
         param_init=0.1,
-        chunk_size_left="0",
         chunk_size_right="0",
         rsp_prob=0,
     )
@@ -54,52 +53,52 @@ def make_args(**kwargs):
     "args",
     [
         # no CNN
-        ({'enc_type': 'blstm', 'chunk_size_left': "20", 'chunk_size_right': "20"}),
-        ({'enc_type': 'blstm', 'chunk_size_left': "32", 'chunk_size_right': "16"}),
-        ({'enc_type': 'lstm', 'chunk_size_left': "1"}),  # unidirectional
-        ({'enc_type': 'lstm', 'chunk_size_left': "40"}),  # unidirectional
+        ({'enc_type': 'blstm', 'chunk_size_current': "20", 'chunk_size_right': "20"}),
+        ({'enc_type': 'blstm', 'chunk_size_current': "32", 'chunk_size_right': "16"}),
+        ({'enc_type': 'lstm', 'chunk_size_current': "1"}),  # unidirectional
+        ({'enc_type': 'lstm', 'chunk_size_current': "40"}),  # unidirectional
         # no CNN, frame stacking
         ({'enc_type': 'blstm', 'n_stacks': 2,
-          'chunk_size_left': "20", 'chunk_size_right': "20"}),
+          'chunk_size_current': "20", 'chunk_size_right': "20"}),
         ({'enc_type': 'blstm', 'n_stacks': 2,
-          'chunk_size_left': "32", 'chunk_size_right': "16"}),
-        ({'enc_type': 'lstm', 'n_stacks': 2, 'chunk_size_left': "2"}),
-        ({'enc_type': 'lstm', 'n_stacks': 3, 'chunk_size_left': "3"}),
+          'chunk_size_current': "32", 'chunk_size_right': "16"}),
+        ({'enc_type': 'lstm', 'n_stacks': 2, 'chunk_size_current': "2"}),
+        ({'enc_type': 'lstm', 'n_stacks': 3, 'chunk_size_current': "3"}),
         # subsample: 1/2
         ({'enc_type': 'conv',
           'conv_channels': "32", 'conv_kernel_sizes': "(3,3)",
           'conv_strides': "(1,1)", 'conv_poolings': "(2,2)",
-          'chunk_size_left': "4"}),
+          'chunk_size_current': "4"}),
         ({'enc_type': 'conv',
           'conv_channels': "32", 'conv_kernel_sizes': "(3,3)",
           'conv_strides': "(1,1)", 'conv_poolings': "(2,2)",
-          'chunk_size_left': "32"}),
+          'chunk_size_current': "32"}),
         # subsample: 1/4
-        ({'enc_type': 'conv', 'chunk_size_left': "8"}),
-        ({'enc_type': 'conv', 'chunk_size_left': "32"}),
-        ({'enc_type': 'conv_lstm', 'chunk_size_left': "8"}),  # unidirectional
-        ({'enc_type': 'conv_lstm', 'chunk_size_left': "40"}),  # unidirectional
+        ({'enc_type': 'conv', 'chunk_size_current': "8"}),
+        ({'enc_type': 'conv', 'chunk_size_current': "32"}),
+        ({'enc_type': 'conv_lstm', 'chunk_size_current': "8"}),  # unidirectional
+        ({'enc_type': 'conv_lstm', 'chunk_size_current': "40"}),  # unidirectional
         ({'enc_type': 'conv_blstm',
-          'chunk_size_left': "20", 'chunk_size_right': "20"}),
+          'chunk_size_current': "20", 'chunk_size_right': "20"}),
         ({'enc_type': 'conv_blstm',
-          'chunk_size_left': "32", 'chunk_size_right': "16"}),
+          'chunk_size_current': "32", 'chunk_size_right': "16"}),
         # subsample: 1/8
         ({'enc_type': 'conv',
           'conv_channels': "32_32_32", 'conv_kernel_sizes': "(3,3)_(3,3)_(3,3)",
           'conv_strides': "(1,1)_(1,1)_(1,1)", 'conv_poolings': "(2,2)_(2,2)_(2,2)",
-          'chunk_size_left': "16"}),
+          'chunk_size_current': "16"}),
         ({'enc_type': 'conv',
           'conv_channels': "32_32_32", 'conv_kernel_sizes': "(3,3)_(3,3)_(3,3)",
           'conv_strides': "(1,1)_(1,1)_(1,1)", 'conv_poolings': "(2,2)_(2,2)_(2,2)",
-          'chunk_size_left': "32"}),
+          'chunk_size_current': "32"}),
         ({'enc_type': 'conv_blstm',
           'conv_channels': "32_32_32", 'conv_kernel_sizes': "(3,3)_(3,3)_(3,3)",
           'conv_strides': "(1,1)_(1,1)_(1,1)", 'conv_poolings': "(2,2)_(2,2)_(2,2)",
-          'chunk_size_left': "32", 'chunk_size_right': "16"}),
+          'chunk_size_current': "32", 'chunk_size_right': "16"}),
         ({'enc_type': 'conv_blstm',
           'conv_channels': "32_32_32", 'conv_kernel_sizes': "(3,3)_(3,3)_(3,3)",
           'conv_strides': "(1,1)_(1,1)_(1,1)", 'conv_poolings': "(2,2)_(2,2)_(2,2)",
-          'chunk_size_left': "64", 'chunk_size_right': "32"}),
+          'chunk_size_current': "64", 'chunk_size_right': "32"}),
     ]
 )
 def test_forward_streaming_chunkwise(args):
@@ -111,16 +110,16 @@ def test_forward_streaming_chunkwise(args):
     device = "cpu"
     atol = 1e-05
 
-    N_l = max(0, int(args['chunk_size_left'].split('_')[0])) // args['n_stacks']
+    N_c = max(0, int(args['chunk_size_current'].split('_')[0])) // args['n_stacks']
     N_r = max(0, int(args['chunk_size_right'].split('_')[0])) // args['n_stacks']
     if unidir:
-        args['chunk_size_left'] = "0"
+        args['chunk_size_current'] = "0"
         args['chunk_size_right'] = "0"
     module = importlib.import_module('neural_sp.models.seq2seq.encoders.rnn')
     enc = module.RNNEncoder(**args)
     enc = enc.to(device)
     if enc.lc_bidir:
-        assert N_l > 0
+        assert N_c > 0
 
     factor = enc.subsampling_factor
     conv_lookahead = enc.conv.context_size if enc.conv is not None else 0
@@ -139,8 +138,8 @@ def test_forward_streaming_chunkwise(args):
                 xs = [module_fs.stack_frame(x, args['n_stacks'], args['n_stacks']) for x in xs]
             else:
                 # zero padding for the last chunk
-                if xmax % N_l != 0:
-                    zero_pad = np.zeros((batch_size, N_l - xmax % N_l, args['input_dim'])).astype(np.float32)
+                if xmax % N_c != 0:
+                    zero_pad = np.zeros((batch_size, N_c - xmax % N_c, args['input_dim'])).astype(np.float32)
                     xs = np.concatenate([xs, zero_pad], axis=1)
 
             xlens = torch.IntTensor([len(x) for x in xs])
@@ -158,12 +157,12 @@ def test_forward_streaming_chunkwise(args):
             # chunk by chunk encoding
             eouts_stream = []
             elens_stream = 0
-            n_chunks = math.ceil(xmax / N_l)
+            n_chunks = math.ceil(xmax / N_c)
             j = 0  # time offset for input
             j_out = 0  # time offset for encoder output
             for chunk_idx in range(n_chunks):
                 start = j - conv_lookahead
-                end = (j + N_l + N_r) + conv_lookahead
+                end = (j + N_c + N_r) + conv_lookahead
                 xs_pad_stream = pad_list(
                     [np2tensor(x[max(0, start):end], device).float() for x in xs], 0.)
                 xlens_stream = torch.IntTensor([xs_pad_stream.size(1) for x in xs])
@@ -172,7 +171,7 @@ def test_forward_streaming_chunkwise(args):
                                           lookback=start >= 0,
                                           lookahead=end <= xmax - 1)
 
-                eout_all_i = enc_out_dict['ys']['xs'][:, j_out:j_out + (N_l // factor)]
+                eout_all_i = enc_out_dict['ys']['xs'][:, j_out:j_out + (N_c // factor)]
                 if eout_all_i.size(1) == 0:
                     break
                 eout_stream_i = enc_out_dict_stream['ys']['xs']
@@ -186,8 +185,8 @@ def test_forward_streaming_chunkwise(args):
                 eouts_stream.append(eout_stream_i)
                 elens_stream += elens_stream_i
 
-                j += N_l
-                j_out += (N_l // factor)
+                j += N_c
+                j_out += (N_c // factor)
                 if j > xmax:
                     break
 


### PR DESCRIPTION
This is for streaming Transformer encoder.
LC-BLSTM does not use `N_l` in the model (but used in the config file, which is replaced with `N_c` inside).