### PR TITLE
CNN lookahead option for LC-BLSTM encoder

### DIFF
--- a/neural_sp/models/seq2seq/encoders/build.py
+++ b/neural_sp/models/seq2seq/encoders/build.py
@@ -152,6 +152,7 @@ def build_encoder(args):
             param_init=args.param_init,
             chunk_size_current=args.lc_chunk_size_left,  # for compatibility
             chunk_size_right=args.lc_chunk_size_right,
+            cnn_lookahead=args.cnn_lookahead,
             rsp_prob=args.rsp_prob_enc)
 
     return encoder

--- a/test/encoders/test_rnn_encoder.py
+++ b/test/encoders/test_rnn_encoder.py
@@ -42,6 +42,7 @@ def make_args(**kwargs):
         param_init=0.1,
         chunk_size_current="0",
         chunk_size_right="0",
+        cnn_lookahead=True,
         rsp_prob=0,
     )
     args.update(kwargs)
@@ -167,8 +168,7 @@ def test_forward(args):
     device = "cpu"
 
     module = importlib.import_module('neural_sp.models.seq2seq.encoders.rnn')
-    enc = module.RNNEncoder(**args)
-    enc = enc.to(device)
+    enc = module.RNNEncoder(**args).to(device)
 
     for xmax in xmaxs:
         xs = np.random.randn(batch_size, xmax, args['input_dim']).astype(np.float32)

--- a/test/encoders/test_rnn_encoder_streaming_chunkwise.py
+++ b/test/encoders/test_rnn_encoder_streaming_chunkwise.py
@@ -47,6 +47,7 @@ def make_args(**kwargs):
         param_init=0.1,
         chunk_size_current="0",
         chunk_size_right="0",
+        cnn_lookahead=True,
         rsp_prob=0,
     )
     args.update(kwargs)
@@ -169,6 +170,7 @@ def test_forward_streaming_chunkwise(args):
             elens_chunk = enc_out_dict_chunk['ys']['xlens']
 
             diff = eout_chunk.size(1) - eout_all_i.size(1)
+
             eout_chunk = eout_chunk[:, :eout_all_i.size(1)]
             elens_chunk -= diff
 

--- a/test/encoders/test_rnn_encoder_streaming_chunkwise.py
+++ b/test/encoders/test_rnn_encoder_streaming_chunkwise.py
@@ -73,14 +73,23 @@ def make_args(**kwargs):
           'conv_channels': "32", 'conv_kernel_sizes': "(3,3)",
           'conv_strides': "(1,1)", 'conv_poolings': "(2,2)",
           'chunk_size_current': "2"}),
+        ({'enc_type': 'conv_blstm',
+          'conv_channels': "32", 'conv_kernel_sizes': "(3,3)",
+          'conv_strides': "(1,1)", 'conv_poolings': "(2,2)",
+          'chunk_size_current': "32", 'chunk_size_right': "16"}),
+        ({'enc_type': 'conv_blstm',
+          'n_layers': 3, 'subsample': '1_2_1',
+          'conv_channels': "32", 'conv_kernel_sizes': "(3,3)",
+          'conv_strides': "(1,1)", 'conv_poolings': "(2,2)",
+          'chunk_size_current': "32", 'chunk_size_right': "16"}),  # hierarchical
         # subsample: 1/4
         ({'enc_type': 'conv', 'chunk_size_current': "8"}),
         ({'enc_type': 'conv', 'chunk_size_current': "32"}),
         ({'enc_type': 'conv_lstm', 'chunk_size_current': "8"}),  # unidirectional
         ({'enc_type': 'conv_lstm', 'chunk_size_current': "40"}),  # unidirectional
         ({'enc_type': 'conv_blstm',
-          'chunk_size_current': "20", 'chunk_size_right': "20"}),
-        ({'enc_type': 'conv_blstm',
+          'chunk_size_current': "32", 'chunk_size_right': "16"}),
+        ({'enc_type': 'conv_blstm', 'cnn_lookahead': False,
           'chunk_size_current': "32", 'chunk_size_right': "16"}),
         # subsample: 1/8
         ({'enc_type': 'conv',
@@ -91,10 +100,6 @@ def make_args(**kwargs):
           'conv_channels': "32_32_32", 'conv_kernel_sizes': "(3,3)_(3,3)_(3,3)",
           'conv_strides': "(1,1)_(1,1)_(1,1)", 'conv_poolings': "(2,2)_(2,2)_(2,2)",
           'chunk_size_current': "32", 'chunk_size_right': "16"}),
-        ({'enc_type': 'conv_blstm',
-          'conv_channels': "32_32_32", 'conv_kernel_sizes': "(3,3)_(3,3)_(3,3)",
-          'conv_strides': "(1,1)_(1,1)_(1,1)", 'conv_poolings': "(2,2)_(2,2)_(2,2)",
-          'chunk_size_current': "64", 'chunk_size_right': "32"}),
     ]
 )
 def test_forward_streaming_chunkwise(args):

--- a/test/frontends/test_streaming.py
+++ b/test/frontends/test_streaming.py
@@ -37,6 +37,7 @@ def make_rnn_args(**kwargs):
         param_init=0.1,
         chunk_size_current="0",
         chunk_size_right="0",
+        cnn_lookahead=True,
         rsp_prob=0,
     )
     args.update(kwargs)


### PR DESCRIPTION
Add an option to disable CNN lookahead for LC-BLSTM encoder