### PR TITLE
Update baseline MoChA on Libirspeech

### DIFF
--- a/examples/librispeech/s5/conf/asr/mocha/lstm_mocha.yaml
+++ b/examples/librispeech/s5/conf/asr/mocha/lstm_mocha.yaml
@@ -20,7 +20,7 @@ mocha_init_r: -4
 mocha_eps: 1e-6
 mocha_std: 1.0
 mocha_1dconv: false
-mocha_quantity_loss_weight: 0.01  ### this is important
+mocha_quantity_loss_weight: 0.1  ### this is important
 attn_sharpening_factor: 1.0
 attn_dim: 512
 attn_n_heads: 1


### PR DESCRIPTION
Increased quantity loss weight from `0.01` to `0.1`