### PR TITLE
Fix dataloader for RNN models

### DIFF
--- a/neural_sp/datasets/asr/build.py
+++ b/neural_sp/datasets/asr/build.py
@@ -97,5 +97,6 @@ def custom_collate_fn(data):
         trigger_points = np.zeros((bs, ymax + 1), dtype=np.int32)
         for b in range(bs):
             trigger_points[b, :len(tmp['trigger_points'][b])] = tmp['trigger_points'][b]
+        tmp['trigger_points'] = trigger_points
 
     return tmp

--- a/neural_sp/datasets/asr/dataloader.py
+++ b/neural_sp/datasets/asr/dataloader.py
@@ -49,7 +49,7 @@ class CustomDataLoader(DataLoader):
     @property
     def epoch_detail(self):
         """Progress of the current epoch."""
-        epoch_ratio = self.batch_sampler._offset / len(self)
+        epoch_ratio = self.batch_sampler.offset / len(self)
         # NOTE: this is not accurate when num_workers > 0
         return epoch_ratio
 

--- a/neural_sp/datasets/asr/dataset.py
+++ b/neural_sp/datasets/asr/dataset.py
@@ -151,6 +151,7 @@ class CustomDataset(Dataset):
             else:
                 setattr(self, 'df_sub' + str(i), None)
 
+        self.wav_input = df['feat_path'][0].split('.')[-1] in ['wav']
         self._input_dim = kaldiio.load_mat(df['feat_path'][0]).shape[-1]
 
         # Remove inappropriate utterances
@@ -311,8 +312,8 @@ class CustomDataset(Dataset):
             assert trigger_points.max() <= xlen - 1, (p, xlen)
             trigger_points //= self.subsample_factor
         elif self.ctc_alignment_dir is not None:
-            trigger_points = np.zeros((1, self.df['ylen'][i] + 1), dtype=np.int32)
-            p = self.df['trigger_points'][i]  # including <eos>
+            trigger_points = np.zeros((self.df['ylen'][i] + 1), dtype=np.int32)
+            p = self.df['trigger_points'][i]  # <eos> is included
             trigger_points[:len(p)] = p  # already 0-indexed
 
         # main outputs

--- a/neural_sp/evaluators/character.py
+++ b/neural_sp/evaluators/character.py
@@ -175,9 +175,9 @@ def eval_char(models, dataloader, recog_params, epoch,
                         last_success_frame_ratio += models[0].last_success_frame_ratio()
                     quantity_rate += models[0].quantity_rate()
 
-                n_utt += len(batch['utt_ids'])
-                if progressbar:
-                    pbar.update(len(batch['utt_ids']))
+            n_utt += len(batch['utt_ids'])
+            if progressbar:
+                pbar.update(len(batch['utt_ids']))
 
     if progressbar:
         pbar.close()

--- a/neural_sp/evaluators/phone.py
+++ b/neural_sp/evaluators/phone.py
@@ -120,9 +120,9 @@ def eval_phone(models, dataloader, recog_params, epoch,
                             n_oracle_hit += len(batch['utt_ids'])
                         per_oracle += pers_b[oracle_idx]
 
-                n_utt += len(batch['utt_ids'])
-                if progressbar:
-                    pbar.update(len(batch['utt_ids']))
+            n_utt += len(batch['utt_ids'])
+            if progressbar:
+                pbar.update(len(batch['utt_ids']))
 
     if progressbar:
         pbar.close()

--- a/neural_sp/evaluators/word.py
+++ b/neural_sp/evaluators/word.py
@@ -174,9 +174,9 @@ def eval_word(models, dataloader, recog_params, epoch,
                         else:
                             wer_dist[xlen_bin] = [err_b / 100]
 
-                n_utt += len(batch['utt_ids'])
-                if progressbar:
-                    pbar.update(len(batch['utt_ids']))
+            n_utt += len(batch['utt_ids'])
+            if progressbar:
+                pbar.update(len(batch['utt_ids']))
 
     if progressbar:
         pbar.close()

--- a/neural_sp/evaluators/wordpiece.py
+++ b/neural_sp/evaluators/wordpiece.py
@@ -152,9 +152,9 @@ def eval_wordpiece(models, dataloader, recog_params, epoch,
                         last_success_frame_ratio += models[0].last_success_frame_ratio()
                     quantity_rate += models[0].quantity_rate()
 
-                n_utt += len(batch['utt_ids'])
-                if progressbar:
-                    pbar.update(len(batch['utt_ids']))
+            n_utt += len(batch['utt_ids'])
+            if progressbar:
+                pbar.update(len(batch['utt_ids']))
 
     if progressbar:
         pbar.close()

--- a/neural_sp/evaluators/wordpiece_bleu.py
+++ b/neural_sp/evaluators/wordpiece_bleu.py
@@ -125,9 +125,9 @@ def eval_wordpiece_bleu(models, dataloader, recog_params, epoch,
                             n_oracle_hit += len(batch['utt_ids'])
                         hypotheses_oracle += [nbest_hyps[oracle_idx].split(' ')]
 
-                n_utt += len(batch['utt_ids'])
-                if progressbar:
-                    pbar.update(len(batch['utt_ids']))
+            n_utt += len(batch['utt_ids'])
+            if progressbar:
+                pbar.update(len(batch['utt_ids']))
 
     if progressbar:
         pbar.close()


### PR DESCRIPTION
- Perform greedy decoding evaluation on the dev set during training with `batch_size=1` for RNN-based models
- Fix bug in CTC alignment loading
- Add `character_length` option to `split_type`