### PR TITLE
Add safeguard for state reset during streaming inference

### DIFF
--- a/neural_sp/models/seq2seq/decoders/las.py
+++ b/neural_sp/models/seq2seq/decoders/las.py
@@ -1636,6 +1636,9 @@ class RNNDecoder(DecoderBase):
 
         self.n_frames += eouts.size(1)
         self.score.reset()
-        self.key_tail = eouts[:, -(self.score.w - 1):]
+        if eouts.size(1) < self.score.w - 1 and self.key_tail is not None:
+            self.key_tail = torch.cat([self.key_tail, eouts], dim=1)[:, -(self.score.w - 1):]
+        else:
+            self.key_tail = eouts[:, -(self.score.w - 1):]
 
         return end_hyps, hyps, hyps_nobd

--- a/neural_sp/models/seq2seq/speech2text.py
+++ b/neural_sp/models/seq2seq/speech2text.py
@@ -657,9 +657,9 @@ class Speech2Text(ModelBase):
                         # Segmentation strategy 2:
                         # If <eos> is emitted from the decoder (not CTC),
                         # the current block is segmented.
-                        if not is_reset:
+                        if (not is_reset) and (not streaming.safeguard_reset):
                             streaming._bd_offset = eout_block.size(1) - 1  # TODO: fix later
-                        is_reset = True
+                            is_reset = True
 
                     if len(best_hyp_id_prefix_viz) > 0:
                         n_frames = self.dec_fwd.ctc.n_frames if ctc_weight == 1 or self.ctc_weight == 1 else self.dec_fwd.n_frames


### PR DESCRIPTION
- Add safeguard
- Add `dualhyp` option
- Add backoff for LSTM encoders
- Fix `key_tail` when block size is smaller than chunk size in MoChA