### PR TITLE
Add set_to_none option for torch>=1.7

### DIFF
--- a/neural_sp/bin/asr/train.py
+++ b/neural_sp/bin/asr/train.py
@@ -445,7 +445,7 @@ def train_one_epoch(model, train_set, dev_set, eval_sets,
                     scheduler.step(skip_optimizer=True)  # update lr only
                 else:
                     scheduler.step()
-                scheduler.zero_grad()
+                scheduler.zero_grad(set_to_none=True)
                 _accum_n_steps = 0
                 reporter.add_scalar('train/total_loss', loss_train)
                 # NOTE: parameters are forcibly updated at the end of every epoch

--- a/neural_sp/trainers/lr_scheduler.py
+++ b/neural_sp/trainers/lr_scheduler.py
@@ -3,6 +3,7 @@
 
 """Learning rate scheduler."""
 
+from distutils.version import LooseVersion
 from glob import glob
 import logging
 import os
@@ -11,6 +12,8 @@ import torch
 from neural_sp.trainers.optimizer import set_optimizer
 
 logger = logging.getLogger(__name__)
+
+torch_17_plus = LooseVersion(torch.__version__) >= LooseVersion("1.7")
 
 
 class LRScheduler(object):
@@ -105,8 +108,11 @@ class LRScheduler(object):
         else:
             self._warmup_lr()
 
-    def zero_grad(self):
-        self.optimizer.zero_grad()
+    def zero_grad(self, set_to_none=False):
+        if torch_17_plus:
+            self.optimizer.zero_grad(set_to_none=set_to_none)
+        else:
+            self.optimizer.zero_grad()
 
     def _noam_lr(self):
         """Warm up and decay learning rate per step based on Transformer."""


### PR DESCRIPTION
Added `set_to_none` option for the optimizer. This is available for `torch>=1.7`.